### PR TITLE
feat(PUP-822): Submit a job and monitor the job status

### DIFF
--- a/example/hello-rescale.nf
+++ b/example/hello-rescale.nf
@@ -8,7 +8,7 @@ process hello {
   x = hifromrescale()
   
   """
-  echo $x
+  sleep 600; echo $x
   """
 }
 

--- a/plugins/nf-rescale-hpc/src/main/nextflow/hello/RescaleTaskHandler.groovy
+++ b/plugins/nf-rescale-hpc/src/main/nextflow/hello/RescaleTaskHandler.groovy
@@ -35,6 +35,27 @@ class RescaleTaskHandler extends TaskHandler implements FusionAwareTask {
         return connection
     }
 
+    protected String jobInformation() {
+        return """
+        {
+            "name": "Example Job V2",
+            "jobanalyses": [
+                {
+                    "analysis": {
+                        "code": "user_included",
+                        "version": "0"
+                    },
+                    "command": "${task.script.trim()}",
+                    "hardware": {
+                        "coreType": "emerald",
+                        "coresPerSlot": 1
+                    }
+                }
+            ]
+        }
+        """
+    }
+
     protected Map<String,String> createJob() {
         HttpURLConnection connection = this.createConnection('/api/v2/jobs/')
         connection.setRequestMethod('POST')
@@ -46,24 +67,7 @@ class RescaleTaskHandler extends TaskHandler implements FusionAwareTask {
         connection.doInput = true
 
         // Body
-        def bodyJson = '''
-        {
-            "name": "Example Job V2",
-            "jobanalyses": [
-                {
-                    "analysis": {
-                        "code": "user_included",
-                        "version": "0"
-                    },
-                    "command": "sleep 600; echo \\"First Job Run!\\"",
-                    "hardware": {
-                        "coreType": "emerald",
-                        "coresPerSlot": 1
-                    }
-                }
-            ]
-        }
-        '''
+        def bodyJson = jobInformation()
 
         connection.outputStream.withWriter {
             writer -> writer.write(bodyJson)

--- a/plugins/nf-rescale-hpc/src/test/nextflow/hello/RescaleTaskHandlerTest.groovy
+++ b/plugins/nf-rescale-hpc/src/test/nextflow/hello/RescaleTaskHandlerTest.groovy
@@ -30,6 +30,7 @@ class RescaleTaskHandlerTest extends Specification {
         def task = Mock(TaskRun)
         def handlerSpy = Spy(RescaleTaskHandler, constructorArgs: [task, executor]) {
             createConnection(_) >> httpURLConnection
+            jobInformation() >> "{}"
         }
 
 
@@ -60,6 +61,8 @@ class RescaleTaskHandlerTest extends Specification {
         def task = Mock(TaskRun)
         def handlerSpy = Spy(RescaleTaskHandler, constructorArgs: [task, executor]) {
             createConnection(_) >> httpURLConnection
+            jobInformation() >> "{}"
+
         }
 
 
@@ -355,4 +358,44 @@ class RescaleTaskHandlerTest extends Specification {
         then: 'throw an exception'
         thrown(AssertionError)
     }
+
+    def 'should return proper json when jobInformation called'() {
+        given: "a RescaleTaskHandler"
+        def executor = Mock(RescaleExecutor) {
+            getRESCALE_PLATFORM_URL() >> "https://example.com"
+            getRESCALE_CLUSTER_TOKEN() >> "test_token"
+        }
+
+        // Spy on class
+        def task = Mock(TaskRun) {
+            script >> "echo Hello World"
+        }
+        def handlerSpy = Spy(RescaleTaskHandler, constructorArgs: [task, executor])
+        
+
+        when: 'checkIfCompleted is called'
+        def value = handlerSpy.jobInformation()
+
+
+        then: 'return false'
+        value == '''
+        {
+            "name": "Example Job V2",
+            "jobanalyses": [
+                {
+                    "analysis": {
+                        "code": "user_included",
+                        "version": "0"
+                    },
+                    "command": "echo Hello World",
+                    "hardware": {
+                        "coreType": "emerald",
+                        "coresPerSlot": 1
+                    }
+                }
+            ]
+        }
+        '''
+    }
+
 }


### PR DESCRIPTION
Ticket: https://rescale.atlassian.net/browse/PUP-822

Nextflow is able to track and display the progress of the job status as shown below, and also exit with an error if the job was stopped manually

### Screenshot of Status update to a submitted job
<img width="594" alt="Screen Shot 2023-09-25 at 2 59 17 PM" src="https://github.com/rescale/nf-rescale-hpc/assets/144736607/1555cf3a-148d-4dba-9402-f75809a5aebd">

<img width="1287" alt="Screen Shot 2023-09-25 at 2 59 42 PM" src="https://github.com/rescale/nf-rescale-hpc/assets/144736607/c61b0b06-95b6-40db-9265-1a46a178fef9">

<img width="1287" alt="Screen Shot 2023-09-25 at 2 59 47 PM" src="https://github.com/rescale/nf-rescale-hpc/assets/144736607/8385831a-194a-479f-9e66-043cd4b0a023">
7/b4ea7e60-67e7-483f-a46c-8ccf3a2ba3ef">

### Manual Job Exited
<img width="377" alt="Screen Shot 2023-09-24 at 4 46 42 PM" src="https://github.com/rescale/nf-rescale-hpc/assets/144736607/f7a6dcc1-b753-4ca0-b776-c4f36af5cc44">