### PR TITLE
feat(PUP-824): Rescale job runs with input environment variables

### DIFF
--- a/example/job-with-input-env.nf
+++ b/example/job-with-input-env.nf
@@ -1,0 +1,24 @@
+process echoEnv {
+    ext.analysisCode="user_included"
+    ext.analysisVersion="0"
+    machineType "emerald"
+    cpus 1
+
+    executor="rescale-executor"
+
+    input:
+    env TEST_ENV
+
+    output:
+    stdout
+
+    script:
+    """
+    echo \$TEST_ENV
+    echo \$TEST_ENV_2
+    """
+
+}
+workflow {
+    Channel.of('123', 'abc') | echoEnv | view
+}

--- a/plugins/nf-rescale-hpc/src/main/nextflow/hello/RescaleJob.groovy
+++ b/plugins/nf-rescale-hpc/src/main/nextflow/hello/RescaleJob.groovy
@@ -3,6 +3,7 @@ package nextflow.hello
 import java.io.File
 
 import groovy.util.logging.Slf4j
+import groovy.json.JsonBuilder
 
 import nextflow.processor.TaskRun
 import nextflow.exception.AbortOperationException
@@ -15,6 +16,23 @@ class RescaleJob {
     
     RescaleJob(TaskRun task) {
         this.task = task
+    }
+
+    protected String envVarsJson() {
+        if (task.getEnvironment() == null) {
+            return "{}"
+        }
+
+        def json = new JsonBuilder(task.getEnvironment())
+
+        return json.toString()
+    }
+
+    protected String commandString() {
+        def command = "cd ~/storage*/projectdata\n" + task.script.trim().split('\n').collect { it.trim() }.join('\n')
+        def json = new JsonBuilder(command)
+
+        return json.toString()
     }
 
     protected String jobConfigurationJson() {
@@ -49,8 +67,8 @@ class RescaleJob {
                         "version": "${task.config.ext.analysisVersion}"
                     },
                     "useRescaleLicense": ${task.config.ext.rescaleLicense},
-                    "envVars": {},
-                    "command": "cd ~/storage*/projectdata; ${task.script.trim()}",
+                    "envVars": ${envVarsJson()},
+                    "command": ${commandString()},
                     "hardware": {
                         "coreType": "${task.config.machineType}",
                         "coresPerSlot": ${task.config.cpus}

--- a/plugins/nf-rescale-hpc/src/test/nextflow/hello/RescaleJobTest.groovy
+++ b/plugins/nf-rescale-hpc/src/test/nextflow/hello/RescaleJobTest.groovy
@@ -45,7 +45,7 @@ class RescaleJobTest extends Specification {
                     },
                     "useRescaleLicense": true,
                     "envVars": {},
-                    "command": "cd ~/storage*/projectdata; echo Hello World",
+                    "command": "cd ~/storage*/projectdata\\necho Hello World",
                     "hardware": {
                         "coreType": "testMachine",
                         "coresPerSlot": 123
@@ -116,5 +116,57 @@ class RescaleJobTest extends Specification {
         then: 'return json with correct config'
         thrown(AbortOperationException)
 
+    }
+    
+    def 'should return a structured commandString of a task when commandString is called'() {
+        given: "a RescaleJob"
+
+        def task = Mock(TaskRun) {
+            script >> """
+            export TEST=1
+            echo \$TEST 
+            """
+        }  
+        def handlerSpy = Spy(RescaleJob, constructorArgs: [task]) 
+        
+
+        when: 'commandString is called'
+        def value = handlerSpy.commandString()
+
+
+        then: 'return string with correct structure'
+        value == '"cd ~/storage*/projectdata\\nexport TEST=1\\necho \$TEST"'
+    }
+
+    def 'should return a environment variables in json format when envVarsJson is called'() {
+        given: "a RescaleJob"
+
+        def task = Mock(TaskRun) {
+            getEnvironment() >> ["TEST_ENV": "123", "TEST_ENV_1": "456"]
+        }  
+        def handlerSpy = Spy(RescaleJob, constructorArgs: [task]) 
+        
+
+        when: 'envVarsJson is called'
+        def value = handlerSpy.envVarsJson()
+
+
+        then: 'return json with correct environment'
+        value == '{"TEST_ENV":"123","TEST_ENV_1":"456"}'
+    }
+
+    def 'should return a empty environment variables in json format if nextflow env is empty'() {
+        given: "a RescaleJob"
+
+        def task = Mock(TaskRun)
+        def handlerSpy = Spy(RescaleJob, constructorArgs: [task]) 
+        
+
+        when: 'envVarsJson is called'
+        def value = handlerSpy.envVarsJson()
+
+
+        then: 'return json with correct environment'
+        value == '{}'
     }
 }


### PR DESCRIPTION
Ticket: https://rescale.atlassian.net/browse/PUP-824

Rescale Job can now run with environment variables passed from the Nextflow to Rescale Job

<img width="896" alt="Screen Shot 2023-10-05 at 5 36 36 PM" src="https://github.com/rescale/nf-rescale-hpc/assets/144736607/a237699c-2c19-4765-b34c-513d123910d1">
